### PR TITLE
Minimap terrain rendered as black

### DIFF
--- a/mods/ca/rules/player.yaml
+++ b/mods/ca/rules/player.yaml
@@ -166,4 +166,5 @@ Player:
 	ResourceStorageWarning:
 	PlayerExperience:
 	ConditionManager:
+    PlayerRadarTerrain:
 	GameSaveViewportManager:


### PR DESCRIPTION
After a player deploys a radar dome or communications center, the minimap radar shows the terrain rendered as black.

This seems to be similar to https://github.com/OpenRA/d2/issues/167, adding the PlayerRadarTerrain trait to the Player actor in mods/ca/rules/player.yaml fixes this and the radar renders the minimap correctly.