### PR TITLE
Overall AI upgrade

### DIFF
--- a/OpenRA.Mods.CA/Traits/BotModules/PowerDownBotModuleCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/PowerDownBotModuleCA.cs
@@ -1,0 +1,153 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.CA.Traits
+{
+	[Desc("Manages AI powerdown.")]
+	public class PowerDownBotModuleCAInfo : ConditionalTraitInfo
+	{
+		[Desc("Delay (in ticks) between toggling powerdown")]
+		public readonly int Interval = 150;
+
+		public override object Create(ActorInitializer init) { return new PowerDownBotModuleCA(init.Self, this); }
+	}
+
+	public class PowerDownBotModuleCA : ConditionalTrait<PowerDownBotModuleCAInfo>, IBotTick
+	{
+		readonly World world;
+		readonly Player player;
+		PowerManager playerPower;
+		int toggleTick;
+		readonly Func<Actor, bool> isToggledBuildingsValid;
+		List<BuildingPowerWrapper> toggledBuildings;
+
+		class BuildingPowerWrapper
+		{
+			public int PowerChanging;
+			public Actor Actor;
+
+			public BuildingPowerWrapper(Actor a, int p)
+			{
+				Actor = a;
+				PowerChanging = p;
+			}
+		}
+
+		public PowerDownBotModuleCA(Actor self, PowerDownBotModuleCAInfo info)
+			: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+			toggledBuildings = new List<BuildingPowerWrapper>();
+			isToggledBuildingsValid = a => a.Owner == self.Owner && !a.IsDead && a.IsInWorld && GetTogglePowerChanging(a) < 0;
+		}
+
+		protected override void Created(Actor self)
+		{
+			// Special case handling is required for the Player actor.
+			// Created is called before Player.PlayerActor is assigned,
+			// so we must query player traits from self, which refers
+			// for bot modules always to the Player actor.
+			playerPower = self.TraitOrDefault<PowerManager>();
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			toggleTick = world.LocalRandom.Next(0, Info.Interval);
+			toggledBuildings = new List<BuildingPowerWrapper>();
+		}
+
+		int GetTogglePowerChanging(Actor a)
+		{
+			var powerChangingIfToggled = 0;
+			var powerTarit = a.TraitsImplementing<Power>().Where(t => !t.IsTraitDisabled).ToArray();
+			var powerMulTrait = a.TraitsImplementing<PowerMultiplier>().ToArray();
+			if (powerTarit.Any())
+			{
+				powerChangingIfToggled = powerTarit.Sum(p => p.Info.Amount) * (powerMulTrait.Sum(p => p.Info.Modifier) - 100) / 100;
+				if (powerMulTrait.Where(t => !t.IsTraitDisabled).Any())
+					powerChangingIfToggled = -powerChangingIfToggled;
+			}
+
+			return powerChangingIfToggled;
+		}
+
+		IEnumerable<Actor> GetToggleableBuildings(IBot bot)
+		{
+			var toggleable = bot.Player.World.ActorsHavingTrait<ToggleConditionOnOrder>(t => !t.IsTraitDisabled && !t.IsTraitPaused)
+				.Where(a => a != null && !a.IsDead && a.Owner == player && a.Info.HasTraitInfo<PowerInfo>() && a.Info.HasTraitInfo<PowerMultiplierInfo>() && a.Info.HasTraitInfo<BuildingInfo>());
+
+			return toggleable;
+		}
+
+		IEnumerable<BuildingPowerWrapper> GetOnlineBuildings(IBot bot)
+		{
+			List<BuildingPowerWrapper> toggleableBuilding = new List<BuildingPowerWrapper>();
+
+			foreach (var a in GetToggleableBuildings(bot))
+			{
+				var powerChanging = GetTogglePowerChanging(a);
+				if (powerChanging > 0)
+					toggleableBuilding.Add(new BuildingPowerWrapper(a, powerChanging));
+			}
+
+			return toggleableBuilding.OrderBy(bpw => bpw.PowerChanging);
+		}
+
+		public void BotTick(IBot bot)
+		{
+			if (toggleTick > 0 || playerPower == null)
+			{
+				toggleTick--;
+				return;
+			}
+
+			var power = playerPower.ExcessPower;
+			toggledBuildings = toggledBuildings.Where(bpw => isToggledBuildingsValid(bpw.Actor)).OrderByDescending(bpw => bpw.PowerChanging).ToList();
+
+			// When there is extra power, check if AI can toggle on
+			if (power > 0)
+			{
+				foreach (var bpw in toggledBuildings)
+				{
+					if (power + bpw.PowerChanging < 0)
+						continue;
+
+					bot.QueueOrder(new Order("PowerDown", bpw.Actor, false));
+					power += bpw.PowerChanging;
+				}
+			}
+
+			// When there is no power, check if AI can toggle off
+			else if (power < 0)
+			{
+				var buildingsCanBeOff = GetOnlineBuildings(bot);
+				foreach (var bpw in buildingsCanBeOff)
+				{
+					if (power > 0)
+						break;
+
+					bot.QueueOrder(new Order("PowerDown", bpw.Actor, false));
+					toggledBuildings.Add(new BuildingPowerWrapper(bpw.Actor, -bpw.PowerChanging));
+					power += bpw.PowerChanging;
+				}
+			}
+
+			toggleTick = Info.Interval;
+		}
+	}
+}

--- a/OpenRA.Mods.CA/Traits/BotModules/SquadManagerBotModuleCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/SquadManagerBotModuleCA.cs
@@ -132,6 +132,12 @@ namespace OpenRA.Mods.CA.Traits
 			unitCannotBeOrdered = a => a == null || a.Owner != Player || a.IsDead || !a.IsInWorld;
 		}
 
+		public bool IsFriendly(Actor a)
+		{
+			return a != null && !a.IsDead && Player.Stances[a.Owner] == Stance.Ally
+				&& !a.Info.HasTraitInfo<HuskInfo>();
+		}
+
 		public bool IsEnemyUnit(Actor a)
 		{
 			return a != null && !a.IsDead && Player.Stances[a.Owner] == Stance.Enemy

--- a/OpenRA.Mods.CA/Traits/BotModules/Squads/States/AirStatesCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/Squads/States/AirStatesCA.cs
@@ -117,59 +117,6 @@ namespace OpenRA.Mods.CA.Traits.BotModules.Squads
 		{
 			return ShouldFlee(owner, enemies => CountAntiAirUnits(enemies) > owner.Units.Count);
 		}
-
-		// Retreat units from combat, or for supply only in idle
-		protected void Retreat(SquadCA owner, bool resupplyonly)
-		{
-			// Reload units.
-			foreach (var a in owner.Units)
-			{
-				var ammoPools = a.TraitsImplementing<AmmoPool>().ToArray();
-				if (!ReloadsAutomatically(ammoPools, a.TraitOrDefault<Rearmable>()) && !FullAmmo(ammoPools))
-				{
-					if (IsRearming(a))
-						continue;
-
-					owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
-					continue;
-				}
-				else if (!resupplyonly)
-					owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
-			}
-
-			// Repair units. One by one to avoid give out mass orders
-			foreach (var a in owner.Units)
-			{
-				if (IsRearming(a))
-					continue;
-
-				Actor repairBuilding = null;
-				var orderId = "Repair";
-				var health = a.TraitOrDefault<IHealth>();
-
-				if (health != null && health.DamageState > DamageState.Undamaged)
-				{
-					var repairable = a.TraitOrDefault<Repairable>();
-					if (repairable != null)
-						repairBuilding = repairable.FindRepairBuilding(a);
-					else
-					{
-						var repairableNear = a.TraitOrDefault<RepairableNearCA>();
-						if (repairableNear != null)
-						{
-							orderId = "RepairNear";
-							repairBuilding = repairableNear.FindRepairBuilding(a);
-						}
-					}
-
-					if (repairBuilding != null)
-					{
-						owner.Bot.QueueOrder(new Order(orderId, a, Target.FromActor(repairBuilding), true));
-						break;
-					}
-				}
-			}
-		}
 	}
 
 	class AirIdleState : AirStateBase, IState
@@ -190,7 +137,7 @@ namespace OpenRA.Mods.CA.Traits.BotModules.Squads
 			var e = FindDefenselessTarget(owner);
 			if (e == null)
 			{
-				Retreat(owner, true);
+				Retreat(owner, false, true, true);
 				return;
 			}
 
@@ -272,7 +219,7 @@ namespace OpenRA.Mods.CA.Traits.BotModules.Squads
 			if (!owner.IsValid)
 				return;
 
-			Retreat(owner, false);
+			Retreat(owner, true, true, true);
 
 			owner.FuzzyStateMachine.ChangeState(owner, new AirIdleState(), true);
 		}

--- a/mods/ca/rules/ai.yaml
+++ b/mods/ca/rules/ai.yaml
@@ -511,6 +511,8 @@ Player:
 		MaximumCaptureTargetOptions: 15
 	BuildingRepairBotModule:
 		RequiresCondition: enable-brutal-ai || enable-vhard-ai || enable-hard-ai || enable-normal-ai || enable-easy-ai || enable-naval-ai
+	PowerDownBotModuleCA:
+		RequiresCondition: enable-brutal-ai || enable-vhard-ai || enable-hard-ai || enable-normal-ai || enable-easy-ai || enable-naval-ai
 	McvManagerBotModuleCA@upper:
 		RequiresCondition: enable-brutal-ai || enable-vhard-ai || enable-hard-ai
 		McvTypes: mcv, amcv


### PR DESCRIPTION
Overall AI upgrade
1.  Update all AI States fixes to my current version:
1.1 Move repair code to "Statebase.cs" on code optimazing.
1.2 Fix a rare crash bug in "GroundState" and optimazing its threat scan && regrouping in AttackMoveState.
1.3 Army in GroundState now will try to reach for the short-game-required actors first when switching target.
1.4 Add retreat and repair for ProtectionState

2.  Add "PowerDownBotModuleCA". AI will try turn off power when powerdown and try restore it later.

3.  When AI uses GroundState army to attack move to a target, it will inform friendly player by using beacon.