### PR TITLE
Try fix the mixed up of Rush and Assault squad units

### DIFF
--- a/OpenRA.Mods.CA/Traits/BotModules/SquadManagerBotModuleCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/SquadManagerBotModuleCA.cs
@@ -347,42 +347,25 @@ namespace OpenRA.Mods.CA.Traits
 
 		void TryToRushAttack(IBot bot)
 		{
-			var allEnemyBaseBuilder = AIUtils.FindEnemiesByCommonName(Info.ConstructionYardTypes, Player);
+			// Note that Rush Squad is almost the same as Assuslt Squad at present.
+			// The meaning of this squad now is not rushing everything to a basebuilder with bugs,
+			// instead, it keeps two squads at bay which is isolated to each other for a bot player,
+			// and performance friendly, while Rush Squad tend to aimming at basebuilder.
+			var randomizedSquadSize = Info.SquadSize + World.LocalRandom.Next(Info.SquadSizeRandomBonus);
 
-			// TODO: This should use common names & ExcludeFromSquads instead of hardcoding TraitInfo checks
-			var ownUnits = activeUnits
-				.Where(unit => unit.IsIdle && unit.Info.HasTraitInfo<AttackBaseInfo>()
-					&& !unit.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(unit.Info.Name) && !unit.Info.HasTraitInfo<HarvesterInfo>()).ToList();
-
-			if (!allEnemyBaseBuilder.Any() || ownUnits.Count < Info.SquadSize)
-				return;
-
-			foreach (var b in allEnemyBaseBuilder)
+			if (unitsHangingAroundTheBase.Count >= randomizedSquadSize)
 			{
-				// Don't rush enemy aircraft!
-				var enemies = World.FindActorsInCircle(b.CenterPosition, WDist.FromCells(Info.RushAttackScanRadius))
-					.Where(unit => IsEnemyUnit(unit) && unit.Info.HasTraitInfo<AttackBaseInfo>() && !unit.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(unit.Info.Name)).ToList();
+				var attackForce = RegisterNewSquad(bot, SquadTypeCA.Rush);
 
-				if (AttackOrFleeFuzzyCA.Rush.CanAttack(ownUnits, enemies))
-				{
-					var target = enemies.Any() ? enemies.Random(World.LocalRandom) : b;
-					var rush = GetSquadOfType(SquadTypeCA.Rush);
-					if (rush == null)
-						rush = RegisterNewSquad(bot, SquadTypeCA.Rush, target);
+				foreach (var a in unitsHangingAroundTheBase)
+					if (!a.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(a.Info.Name))
+						attackForce.Units.Add(a);
+				var enemybase = AIUtils.FindEnemiesByCommonName(Info.ConstructionYardTypes, Player).Random(World.LocalRandom);
+				attackForce.TargetActor = enemybase;
 
-					foreach (var a3 in ownUnits)
-					{
-						var protectSq = GetSquadOfType(SquadTypeCA.Protection);
-						if (protectSq != null)
-						{
-							protectSq.Units.Remove(a3);
-						}
-
-						rush.Units.Add(a3);
-					}
-
-					return;
-				}
+				unitsHangingAroundTheBase.Clear();
+				foreach (var n in notifyIdleBaseUnits)
+					n.UpdatedIdleBaseUnits(unitsHangingAroundTheBase);
 			}
 		}
 


### PR DESCRIPTION
This pr try fix bug reported in this [issue](https://github.com/OpenRA/OpenRA/issues/18500#issue-675675734).

In SP I happened to set the "RushInterval" very long and kinda erase the bug, but in CA this bug is very obvious: when Rush and Assault squad refresh rapidly, there will be very high chance that a unit will both belong to Rush and Assault squad. When two squads heading to different direction, the regroup mechanic of the two squad will make both of the squad immobilized due to the shared unit. while there will be units add to those two squad which will cause bigger lag.