### PR TITLE
Fix mindcontrol landing aircraft crash the game

### DIFF
--- a/mods/ca/rules/defaults.yaml
+++ b/mods/ca/rules/defaults.yaml
@@ -1435,6 +1435,7 @@
 	Inherits@4: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableCombatUnit
+	Inherits@mind: ^MindControllable
 	Huntable:
 	OwnerLostAction:
 		Action: Kill


### PR DESCRIPTION
Fixes #15. Only first part for crash bug. 

Like what I referred in #15. You can reproduce this crash bug by simply build any kind of aircraft and mind control them when they landing. You will get crash and message like below:

`mast` tried to mindcontrol `tran`, but the latter does not have the necessary trait!

I still suggest to check if everything can be target by mindcontrol weapon have the mindcontrollable trait, or if they don't have the trait but they are completely untargetable by mindcontrol weapon at any condition. I am afraid there is probably more than aircraft units can cause this crush.

PS: another cargo bug in #15 need an engine fix, or you can create a CargoCA for that.