### PR TITLE
squad up to date

### DIFF
--- a/OpenRA.Mods.CA/Traits/BotModules/SquadManagerBotModuleCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/SquadManagerBotModuleCA.cs
@@ -231,6 +231,16 @@ namespace OpenRA.Mods.CA.Traits
 			return ret;
 		}
 
+		public void DismissSquad(SquadCA squad)
+		{
+			foreach (var unit in squad.Units)
+			{
+				unitsHangingAroundTheBase.Add(unit);
+			}
+
+			squad.Units.Clear();
+		}
+
 		void AssignRolesToIdleUnits(IBot bot)
 		{
 			CleanSquads();

--- a/OpenRA.Mods.CA/Traits/BotModules/Squads/States/GroundStatesCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/Squads/States/GroundStatesCA.cs
@@ -275,6 +275,6 @@ namespace OpenRA.Mods.CA.Traits.BotModules.Squads
 			owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleState(), false);
 		}
 
-		public void Deactivate(SquadCA owner) { owner.Units.Clear(); }
+		public void Deactivate(SquadCA owner) { owner.SquadManager.DismissSquad(owner); }
 	}
 }

--- a/OpenRA.Mods.CA/Traits/BotModules/Squads/States/NavyStatesCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/Squads/States/NavyStatesCA.cs
@@ -190,6 +190,6 @@ namespace OpenRA.Mods.CA.Traits.BotModules.Squads
 			owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsIdleState(), false);
 		}
 
-		public void Deactivate(SquadCA owner) { owner.Units.Clear(); }
+		public void Deactivate(SquadCA owner) { }
 	}
 }

--- a/OpenRA.Mods.CA/Traits/BotModules/Squads/States/NavyStatesCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/Squads/States/NavyStatesCA.cs
@@ -99,6 +99,10 @@ namespace OpenRA.Mods.CA.Traits.BotModules.Squads
 
 	class NavyUnitsAttackMoveState : NavyStateBase, IState
 	{
+		int lastUpdatedTick;
+		CPos? lastLeaderLocation;
+		Actor lastTarget;
+
 		public void Activate(SquadCA owner) { }
 
 		public void Tick(SquadCA owner)
@@ -129,6 +133,31 @@ namespace OpenRA.Mods.CA.Traits.BotModules.Squads
 				}
 			}
 
+			var leader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
+			if (leader == null)
+				return;
+
+			if (leader.Location != lastLeaderLocation)
+			{
+				lastLeaderLocation = leader.Location;
+				lastUpdatedTick = owner.World.WorldTick;
+			}
+
+			if (owner.TargetActor != lastTarget)
+			{
+				lastTarget = owner.TargetActor;
+				lastUpdatedTick = owner.World.WorldTick;
+			}
+
+			// HACK: Drop back to the idle state if we haven't moved in 2.5 seconds
+			// This works around the squad being stuck trying to attack-move to a location
+			// that they cannot path to, generating expensive pathfinding calls each tick.
+			if (owner.World.WorldTick > lastUpdatedTick + 63)
+			{
+				owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsIdleState(), true);
+				return;
+			}
+
 			// Save whether we had an Enemy naval yard this tick.
 			hadNavalYard = navalProductions.Any();
 
@@ -147,6 +176,10 @@ namespace OpenRA.Mods.CA.Traits.BotModules.Squads
 
 	class NavyUnitsAttackState : NavyStateBase, IState
 	{
+		int lastUpdatedTick;
+		CPos? lastLeaderLocation;
+		Actor lastTarget;
+
 		public void Activate(SquadCA owner) { }
 
 		public void Tick(SquadCA owner)
@@ -164,6 +197,28 @@ namespace OpenRA.Mods.CA.Traits.BotModules.Squads
 					owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsFleeState(), false);
 					return;
 				}
+			}
+
+			var leader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
+			if (leader.Location != lastLeaderLocation)
+			{
+				lastLeaderLocation = leader.Location;
+				lastUpdatedTick = owner.World.WorldTick;
+			}
+
+			if (owner.TargetActor != lastTarget)
+			{
+				lastTarget = owner.TargetActor;
+				lastUpdatedTick = owner.World.WorldTick;
+			}
+
+			// HACK: Drop back to the idle state if we haven't moved in 2.5 seconds
+			// This works around the squad being stuck trying to attack-move to a location
+			// that they cannot path to, generating expensive pathfinding calls each tick.
+			if (owner.World.WorldTick > lastUpdatedTick + 63)
+			{
+				owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsIdleState(), true);
+				return;
 			}
 
 			foreach (var a in owner.Units)


### PR DESCRIPTION
1. Dismissed ground squad unit join idle units, avoid dismissed ground squad units stay at home forever.
2. Don't allow navy dismissed, because idle units in SquadManager will only join ground squad
3. Add stuck check for Navy from upstream for performance.
