### PR TITLE
fix typos in descriptions

### DIFF
--- a/mods/ca/rules/aircraft.yaml
+++ b/mods/ca/rules/aircraft.yaml
@@ -2691,7 +2691,7 @@ KIRO:
 		BuildAtProductionType: Helicopter
 		BuildPaletteOrder: 82
 		Prerequisites: afld, stek, ~aircraft.kiro, ~techlevel.high
-		Description: Heavily armoured airship armed with specialised bombs.
+		Description: Heavily armored airship armed with specialised bombs.
 	TooltipExtras:
 		Strengths: • Strong vs Buildings, Defenses, Infantry, Light Armor
 		Weaknesses: • Cannot attack Aircraft\n• Has difficulty hitting moving targets\n• Vulnerable when dropping bombs
@@ -4780,7 +4780,7 @@ DISC:
 		BuildAtProductionType: Helicopter
 		BuildPaletteOrder: 83
 		Prerequisites: afld, stek, ~aircraft.yuri, ~techlevel.high
-		Description: Heavily armoured attack craft.
+		Description: Heavily armored attack craft.
 	TooltipExtras:
 		Strengths: • Strong vs Buildings, Defenses, Light Armor
 		Attributes: • Shuts down power\n• Drains resources from refineries

--- a/mods/ca/rules/civilian.yaml
+++ b/mods/ca/rules/civilian.yaml
@@ -478,7 +478,7 @@ MISS:
 		Description: Provides vision of the surrounding area.
 		ValidRelationships: Ally
 	TooltipDescription@other:
-		Description: Capture to provide vison of surrounding area.
+		Description: Capture to provide vision of surrounding area.
 		ValidRelationships: Neutral, Enemy
 	WithBuildingBib:
 	CaptureManager:

--- a/mods/ca/rules/powers.yaml
+++ b/mods/ca/rules/powers.yaml
@@ -1927,7 +1927,7 @@
 		Name: Ichor Seed
 		LifeTime: -1
 		AllowMultiple: false
-		Description: \nGrows tiberium at selected location.
+		Description: \nGrows Tiberium at selected location.
 		LaunchSound: ichorseed.aud
 		SelectTargetSpeechNotification: SelectTarget
 		SelectTargetTextNotification: Select target.
@@ -1948,7 +1948,7 @@
 		Name: Ichor Seed
 		LifeTime: -1
 		AllowMultiple: false
-		Description: \nGrows tiberium at selected location.
+		Description: \nGrows Tiberium at selected location.
 		LaunchSound: ichorseed.aud
 		SelectTargetSpeechNotification: SelectTarget
 		SelectTargetTextNotification: Select target.

--- a/mods/ca/rules/scrin.yaml
+++ b/mods/ca/rules/scrin.yaml
@@ -1748,7 +1748,7 @@ INTL:
 		BuildPaletteOrder: 110
 		Prerequisites: ~vehicles.scrin, ~techlevel.low
 		Queue: VehicleSQ, VehicleMQ
-		Description: Heavily armoured front-line assault vehicle and troop carrier.
+		Description: Heavily armored front-line assault vehicle and troop carrier.
 		IconPalette: chrome
 	TooltipExtras:
 		Strengths: • Strong vs Heavy Armor, Light Armor

--- a/mods/ca/rules/upgrades.yaml
+++ b/mods/ca/rules/upgrades.yaml
@@ -18,7 +18,7 @@ hazmat.upgrade:
 		BuildPaletteOrder: 19
 		Prerequisites: anyradar, infantry.any, ~!player.soviet, ~!player.zocom, ~!player.scrin, ~techlevel.medium
 		IconPalette: chrometd
-		Description: Infantry are equiped with hazmat suits which provides\n  protection against Tiberium and radiation.\n\nUpgrades: Infantry
+		Description: Infantry are equipped with hazmat suits which provides\n  protection against Tiberium and radiation.\n\nUpgrades: Infantry
 	TooltipExtras:
 		Strengths: + Tiberium immunity\n+ 50% resistance to irradiated terrain
 	Valued:
@@ -36,7 +36,7 @@ flakarmor.upgrade:
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: techcenter.any, infantry.any, ~!player.nod, ~!player.scrin, ~techlevel.high
-		Description: Infantry are equiped with advanced flak armor which\n  provides protection against explosives.\n\nUpgrades: Infantry
+		Description: Infantry are equipped with advanced flak armor which\n  provides protection against explosives.\n\nUpgrades: Infantry
 	TooltipExtras:
 		Strengths: + 40% reduced damage from explosives\n+ 20% reduced damage from incendiary explosives
 	Valued:
@@ -987,7 +987,7 @@ gattling.upgrade:
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: ~player.yuri, anyradar, ~techlevel.medium
-		Description: Upgrades BTR's with dual gattling cannons.\n\nReplaces: BTR
+		Description: Upgrades BTRs with dual gattling cannons.\n\nReplaces: BTR
 	TooltipExtras:
 		Strengths: + Increased firepower
 		Weaknesses: – Increased production cost
@@ -1692,7 +1692,7 @@ ioncon.upgrade:
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: ~player.scrin, scrt, ~techlevel.high
-		Description: Allows Storm Colums and Stormcrawlers to store ion energy and\n  release it into the atmosphere, creating a localised Ion Storm.\n\nUpgrades: Storm Column\nUpgrades: Stormcrawler
+		Description: Allows Storm Columns and Stormcrawlers to store ion energy and\n  release it into the atmosphere, creating a localized Ion Storm.\n\nUpgrades: Storm Column\nUpgrades: Stormcrawler
 		IconPalette: chromes
 	TooltipExtras:
 		Strengths: + Increases damage and range over time when active\n+ Reduces incoming damage over time when active\n+ Ion storm can damage enemy units and structures

--- a/mods/ca/rules/vehicles.yaml
+++ b/mods/ca/rules/vehicles.yaml
@@ -9850,7 +9850,7 @@ ZEUS:
 		Queue: VehicleSQ, VehicleMQ
 		BuildPaletteOrder: 224
 		Prerequisites: ~vehicles.allies, alhq, ~greece.coalition, ~techlevel.high
-		Description: Extreme long range artillery that can generate localised storm clouds.
+		Description: Extreme long range artillery that can generate localized storm clouds.
 	TooltipExtras:
 		Strengths: • Strong vs Buildings, Defenses
 		Weaknesses: • Cannot attack Aircraft\n• Has difficulty hitting moving targets\n• Cannot fire while moving


### PR DESCRIPTION
This fixes a few typos: a few genuine ones, a few for consistency that change British to American spelling (since most seems to use American English) and twice where "tiberium" was spelled lower-case while 15 other times it was spelled "Tiberium".